### PR TITLE
Added functionality for Discord IDs

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -4,15 +4,15 @@ export const Footer = () => {
   return (
     <footer className="mt-10 py-4 text-center text-sm text-zinc-500 border-t border-zinc-700">
       <p className="flex justify-center items-center gap-2">
-        <span>&copy; {new Date().getFullYear()} Michael Isler</span>
+        <span>&copy; {new Date().getFullYear()} Dirty Tactics</span>
         <a
-          href="https://github.com/mcalihe"
+          href="https://github.com/JonasKaad/DawnFormatter"
           target="_blank"
           rel="noopener noreferrer"
           className="flex items-center gap-1 text-blue-400 hover:underline"
         >
           <Github className="w-4 h-4" />
-          <span>@mcalihe</span>
+          <span>@JonasKaad</span>
         </a>
       </p>
     </footer>

--- a/src/components/cards/PlayerCard.tsx
+++ b/src/components/cards/PlayerCard.tsx
@@ -83,10 +83,12 @@ export const PlayerCard = ({ player, onUpdatePlayer, onDeletePlayer }: PlayerCar
             mode={'edit'}
             initialName={player.name}
             initialDiscord={player.discord}
+            initialDiscordId={player.discordId}
             onClose={() => setEditPlayerModalOpen(false)}
-            onSave={({ name, discord }) => {
+            onSave={({ name, discord, discordId }) => {
               player.name = name
               player.discord = discord
+              player.discordId = discordId
               onUpdatePlayer()
             }}
           />

--- a/src/components/modals/EditPlayerModal.tsx
+++ b/src/components/modals/EditPlayerModal.tsx
@@ -11,7 +11,8 @@ interface NewPlayerModalProps {
   mode: 'create' | 'edit'
   initialName?: string
   initialDiscord?: string
-  onSave: (data: { name: string; discord?: string }) => void
+  initialDiscordId?: string
+  onSave: (data: { name: string; discord?: string; discordId?: string }) => void
 }
 
 export const EditPlayerModal = ({
@@ -21,21 +22,25 @@ export const EditPlayerModal = ({
   mode = 'edit',
   initialName,
   initialDiscord,
+  initialDiscordId,
 }: NewPlayerModalProps) => {
   const { t } = useTranslation()
   const [name, setName] = useState(initialName ?? '')
   const [discord, setDiscord] = useState(initialDiscord ?? '')
+  const [discordId, setDiscordId] = useState(initialDiscordId ?? '')
 
   useEffect(() => {
     if (open) {
       setName(initialName ?? '')
       setDiscord(initialDiscord ?? '')
+      setDiscordId(initialDiscordId ?? '')
     }
-  }, [open, initialName, initialDiscord])
+  }, [open, initialName, initialDiscord, initialDiscordId])
 
   const resetData = () => {
     setName(initialName ?? '')
     setDiscord(initialDiscord ?? '')
+    setDiscordId(initialDiscordId ?? '')
   }
 
   const handleClose = () => {
@@ -44,7 +49,7 @@ export const EditPlayerModal = ({
   }
 
   const handleSave = () => {
-    onSave({ name, discord: discord || undefined })
+    onSave({ name, discord: discord || undefined, discordId: discordId || undefined })
     handleClose()
   }
 
@@ -78,6 +83,12 @@ export const EditPlayerModal = ({
             label={t('modal.newPlayer.discord.label')}
             value={discord}
             onChange={(e) => setDiscord(e.target.value)}
+          />
+          <FloatingInput
+            id="player-discord-id"
+            label={t('modal.newPlayer.discordId.label')}
+            value={discordId}
+            onChange={(e) => setDiscordId(e.target.value)}
           />
 
           <div className="flex justify-end gap-3 pt-4">

--- a/src/data/StorageKeys.ts
+++ b/src/data/StorageKeys.ts
@@ -1,3 +1,4 @@
 export const TEAMS = 'teams'
 export const CURRENT_TEAM = 'current_team'
 export const LANGUAGE = 'language'
+export const USE_DISCORD_ID = 'use_discord_id'

--- a/src/locales/da.json
+++ b/src/locales/da.json
@@ -56,7 +56,8 @@
   "modal.editPlayer.title": "Rediger spiller",
   "modal.newPlayer.title": "Tilføj ny spiller",
   "modal.newPlayer.name.label": "Navn",
-  "modal.newPlayer.discord.label": "Discord navn (valgfrit)",
+  "modal.newPlayer.discord.label": "Discord Navn (valgfrit)",
+  "modal.newPlayer.discordId.label": "Discord ID (valgfrit)",
   "modal.edit.team.title": "Rediger team",
   "modal.add.team.title": "Tilføj nyt team",
   "modal.team.name.label": "Team navn",
@@ -148,5 +149,6 @@
   "spec.protectionWarrior": "Protection",
   "trade.all.armor": "Handel alle",
   "trade.all.armor.except": "Handel alle undtagen: ",
-  "no.players.active": "Ingen aktive karakterer"
+  "no.players.active": "Ingen aktive karakterer",
+  "discord.format.toggle.label": "Brug Discord ID i stedet for navn"
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -57,6 +57,7 @@
   "modal.newPlayer.title": "Add new player",
   "modal.newPlayer.name.label": "Name",
   "modal.newPlayer.discord.label": "Discord name (optional)",
+  "modal.newPlayer.discordId.label": "Discord ID (optional)",
   "modal.edit.team.title": "Edit team",
   "modal.add.team.title": "Add new team",
   "modal.team.name.label": "Team name",
@@ -148,5 +149,6 @@
   "spec.protectionWarrior": "Protection",
   "trade.all.armor": "Trade all",
   "trade.all.armor.except": "Trade all except: ",
-  "no.players.active": "No active characters"
+  "no.players.active": "No active characters",
+  "discord.format.toggle.label": "Use Discord ID instead of name"
 }

--- a/src/models/Player.ts
+++ b/src/models/Player.ts
@@ -4,5 +4,6 @@ export interface Player {
   id: number
   name: string
   discord?: string
+  discordId?: string
   characters: Character[]
 }

--- a/src/services/DataStorageService.ts
+++ b/src/services/DataStorageService.ts
@@ -1,4 +1,4 @@
-import { CURRENT_TEAM, TEAMS } from '../data/StorageKeys'
+import { CURRENT_TEAM, TEAMS, USE_DISCORD_ID } from '../data/StorageKeys'
 import { Teams } from '../data/Teams'
 
 export interface StoredTeamsData {
@@ -54,5 +54,14 @@ export class DataStorageService {
 
   static saveCurrentTeamKey(currentTeamKey: string): void {
     localStorage.setItem(CURRENT_TEAM, currentTeamKey)
+  }
+
+  static saveUseDiscordId(useDiscordId: boolean): void {
+    localStorage.setItem(USE_DISCORD_ID, String(useDiscordId))
+  }
+
+  static loadUseDiscordIdFromLocalStorage(): boolean {
+    const savedValue = localStorage.getItem(USE_DISCORD_ID)
+    return savedValue === 'true'
   }
 }

--- a/src/services/DiscordFormatService.ts
+++ b/src/services/DiscordFormatService.ts
@@ -22,7 +22,8 @@ export class DiscordFormatService {
     players: Player[],
     classTranslations: Record<Class, string>,
     armorSlotTranslations: Record<ArmorSlot, string>,
-    translateFn: (key: string) => string
+    translateFn: (key: string) => string,
+    useDiscordId: boolean = false
   ): string {
     const activePlayers = players.filter((p) => p.characters.filter((c) => c.active).length > 0)
     if (activePlayers.length < 1) {
@@ -38,6 +39,7 @@ export class DiscordFormatService {
           classTranslations,
           armorSlotTranslations,
           translateFn,
+          useDiscordId,
           activePlayers.length === 1 ? undefined : idx + 1
         )
       )
@@ -51,6 +53,7 @@ export class DiscordFormatService {
     classTranslations: Record<Class, string>,
     armorSlotTranslations: Record<ArmorSlot, string>,
     translateFn: (key: string) => string,
+    useDiscordId: boolean = false,
     number?: number
   ): string {
     if (player.characters.length < 1) {
@@ -62,7 +65,16 @@ export class DiscordFormatService {
     )
 
     const playerInfo = number ? `Player${number} ` : ''
-    const playerDiscord = player.discord !== undefined ? `@${player.discord} ` : ''
+
+
+    let playerDiscord = player.discord !== undefined ? `@${player.discord} ` : `<@${player.discordId}>`
+
+    if (useDiscordId && player.discordId) {
+      playerDiscord = `<@${player.discordId}> `
+    } else if (player.discord) {
+      playerDiscord = `@${player.discord} `
+    } 
+
     const header = `${playerInfo}${playerDiscord}:Raiderio: ${highestScore}`
     const characterLines = player.characters
       .filter((c) => c.active)

--- a/src/services/DiscordFormatService.ts
+++ b/src/services/DiscordFormatService.ts
@@ -74,6 +74,9 @@ export class DiscordFormatService {
     } else if (player.discord) {
       playerDiscord = `@${player.discord} `
     } 
+    if(!player.discord && !player.discordId) {
+      playerDiscord = ''
+    }
 
     const header = `${playerInfo}${playerDiscord}:Raiderio: ${highestScore}`
     const characterLines = player.characters


### PR DESCRIPTION
This pull request introduces support for storing and using Discord IDs for players, allowing users to choose between referencing players by their Discord name or Discord ID in the output. It also adds a toggle in the UI to switch between these formats.

This closes #1 

<img width="1040" height="408" alt="image" src="https://github.com/user-attachments/assets/6d16074e-3414-4d5a-9a71-b77f52fe747b" />
